### PR TITLE
Case sensitive parameter names in apm.yml (deprecated since Symfony 3.4)

### DIFF
--- a/Resources/config/apm.yml
+++ b/Resources/config/apm.yml
@@ -40,6 +40,6 @@ services:
     berriart_apm.handler:
         class: "%berriart_apm.handler.class%"
     berriart_apm.client.app_insights:
-        class: "%berriart_apm.Client.app_insights.class%"
+        class: "%berriart_apm.client.app_insights.class%"
     "%berriart_apm.service.alias%":
         alias: berriart_apm.handler


### PR DESCRIPTION
Make symfony >= 3.4 happy due to this warning:

```Parameter names will be made case sensitive in Symfony 4.0. Using "berriart_apm.Client.app_insights.class" instead of "berriart_apm.client.app_insights.class" is deprecated since Symfony 3.4.```